### PR TITLE
(GH-308) fix/Modify backend coverage command in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
       run: |
         # Run tests and collect coverage in XML format using settings from root
         # We use ../coverage.settings.xml because the working-directory is 'backend'
-        dotnet-coverage collect "dotnet test --no-build" -f xml -o "coverage.xml" -s "coverage.settings.xml"
+        dotnet-coverage collect "dotnet test --configuration Debug --no-restore" -f xml -o "coverage.xml" -s "../coverage.settings.xml"
 
         # Confirm file exists
         if (!(Test-Path "coverage.xml")) {


### PR DESCRIPTION
# Objectives of the Pull Request ? 
This pull request makes a small improvement to the test and coverage step in the GitHub Actions workflow. The change ensures that `dotnet test` runs in Debug configuration, skips package restore, and uses the correct path to the coverage settings file.

The issue was that the dotnet-coverage tool was using the no build flag which led it to not run using the correct backend.csproj. By rebuilding we ensure that the coverage tool will use the backend.Tests.csproj which is the correct configuration file for the testing environment.

* Updated the `dotnet-coverage collect` command in `.github/workflows/build.yml` to run tests with `--configuration Debug`, skip restore with `--no-restore`, and reference the correct `../coverage.settings.xml` path.Updated test command to include Debug configuration and no-restore option.

# How to run the pull request ?
> Provide the code required to run the pull request. This is the code that will be used to review your pull request. **The provided code must work as-is. If a react-native error is raised while running the code, the PR will be rejected. The following code / placeholder is only provided as documentation / helper to get you started and you will need to adjust it.**

```bash
# Update the code
git checkout fix/CI-pipeline-backend-test-not-mismatched-namespace-during-testing
git pull
# Might be required if you update check the PR

```